### PR TITLE
Handling refresh token returned in user login  response

### DIFF
--- a/frontend/src/components/AuthContext.tsx
+++ b/frontend/src/components/AuthContext.tsx
@@ -96,11 +96,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   // Update apiService token when it changes
   useEffect(() => {
-    if (token) {
-      // Update axios instance configuration
-      const axiosInstance = apiService['api'];
-      axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${token}`;
-    }
+    apiService.setAuthToken(token);
   }, [token]);
 
   const value = {


### PR DESCRIPTION
The following Pr increases UI via efficient used of refresh-token send in login response,it is use to generate new access token if old one expires.
Fix #27 